### PR TITLE
extractModel - new feature

### DIFF
--- a/src/Crud.php
+++ b/src/Crud.php
@@ -247,4 +247,19 @@ abstract class Crud
         return $this->logSQL ?? "";
     }
 
+       public function extractModel($model): \stdClass{
+        $reflection = new \ReflectionClass(get_class($model)); 
+        $objeto = new \stdClass; 
+
+        foreach ($reflection->getProperties() as $prop) {
+            $method = 'get'.$prop->name ; 
+            $objeto->{$prop->name} =  call_user_func([$model, $method]); 
+            
+        }
+
+        return $objeto ; 
+
+
+    }
+
 }


### PR DESCRIPTION
método que permite extrair as propriedades protegidas da model diretamente para o DAO

com o méetodo
<img width="747" alt="image" src="https://github.com/user-attachments/assets/2decf4b6-e120-46d4-b0c7-8674b6496464">


sem o método preciso ficar declarando atributo por atributo novamente 
<img width="668" alt="image" src="https://github.com/user-attachments/assets/d91137c2-4dcd-42d0-8e4f-bbc6bfe41f26">
